### PR TITLE
ci: add release workflow and update CHANGELOG format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from CHANGELOG
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=## \[)[^\]]+(?=\])' CHANGELOG.md | grep -v '^Unreleased$' | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "No release version found in CHANGELOG.md"
+            VERSION="Unreleased"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Check if tag exists
+        id: check
+        if: steps.version.outputs.version != 'Unreleased'
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.version }}$"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.version.outputs.version }} does not exist"
+          fi
+
+      - name: Create and push tag
+        if: steps.version.outputs.version != 'Unreleased' && steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}
+          echo "Created tag: ${{ steps.version.outputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-Versioning: `<upstream-version>-nix.<revision>`
+All notable changes to this project will be documented in this file.
 
-## 0.3.2-nix.1
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-- Initial release
-- Based on upstream octorus v0.3.2
+## Versioning Scheme
+
+This project uses the format: `<octorus-version>-nix.<revision>`
+
+- When octorus upstream updates: Update the octorus version part
+- When octorus-nix changes: Increment the `-nix.X` revision
+
+## [Unreleased]
+
+## [0.3.2-nix.1] - 2026-02-11
+
+### Added
+
+- Initial Nix flake for octorus v0.3.2
+- CI workflow for PR build & test
+- Release workflow for CHANGELOG-based auto-tagging
+- Cachix binary cache (`octorus-nix`)
+
+[Unreleased]: https://github.com/naitokosuke/octorus-nix/compare/0.3.2-nix.1...HEAD
+[0.3.2-nix.1]: https://github.com/naitokosuke/octorus-nix/releases/tag/0.3.2-nix.1


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` for auto-tagging based on CHANGELOG.md
- Update CHANGELOG.md to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with `## [version]` bracket syntax

Closes #2

## How it works

On push to `main`, extracts the latest version from `## [x.y.z-nix.N]` in CHANGELOG.md and creates a git tag if it doesn't already exist.

## Test plan

- [ ] Merge this PR and verify tag `0.3.2-nix.1` is created automatically
- [ ] Verify no duplicate tags are created on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)