### PR TITLE
ci: add auto-update workflow for upstream octorus

### DIFF
--- a/.github/workflows/update-octorus.yml
+++ b/.github/workflows/update-octorus.yml
@@ -1,0 +1,163 @@
+name: Update octorus version
+
+on:
+  schedule:
+    # Check every 12 hours (at 00:00 and 12:00 UTC)
+    - cron: '0 0,12 * * *'
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  check-update:
+    runs-on: macos-latest # aarch64-darwin
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: octorus-nix
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Get current version
+        id: current
+        run: |
+          set -e
+          CURRENT_VERSION=$(grep 'version = "' flake.nix | head -1 | sed 's/.*version = "\([^"]*\)".*/\1/')
+          if [ -z "$CURRENT_VERSION" ]; then
+            echo "Error: Could not extract current version from flake.nix"
+            exit 1
+          fi
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Get latest version from GitHub
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          # Fetch all tags and sort by semantic version to get the latest
+          LATEST_VERSION=$(gh api repos/ushironoko/octorus/tags --paginate --jq '.[].name' | sed 's/^v//' | sort -V | tail -1)
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "Error: Could not fetch latest version from GitHub"
+            exit 1
+          fi
+          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          echo "Latest version: $LATEST_VERSION"
+
+      - name: Check if update is needed
+        id: check
+        run: |
+          set -e
+          if [ "${{ steps.current.outputs.version }}" != "${{ steps.latest.outputs.version }}" ]; then
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+            echo "Update needed: ${{ steps.current.outputs.version }} -> ${{ steps.latest.outputs.version }}"
+          else
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+            echo "Already up to date"
+          fi
+
+      - name: Update flake.nix
+        if: steps.check.outputs.needs_update == 'true'
+        run: |
+          set -e
+          NEW_VERSION="${{ steps.latest.outputs.version }}"
+
+          # Use GNU sed via Nix for compatibility with macOS
+          GSED="nix run nixpkgs#gnused --"
+
+          # Update version (only first occurrence)
+          $GSED -i "0,/version = \"[^\"]*\"/s//version = \"$NEW_VERSION\"/" flake.nix
+
+          # Get new hash using nix-prefetch
+          echo "Fetching hash for version $NEW_VERSION..."
+          PREFETCH_HASH=$(nix-prefetch-url --unpack "https://github.com/ushironoko/octorus/archive/refs/tags/v${NEW_VERSION}.tar.gz")
+          if [ -z "$PREFETCH_HASH" ]; then
+            echo "Error: Failed to prefetch source"
+            exit 1
+          fi
+          NEW_HASH=$(nix hash to-sri --type sha256 "$PREFETCH_HASH")
+          if [ -z "$NEW_HASH" ]; then
+            echo "Error: Failed to convert hash to SRI format"
+            exit 1
+          fi
+          echo "Got hash: $NEW_HASH"
+
+          # Update hash (only first occurrence)
+          $GSED -i "0,/hash = \"sha256-[^\"]*\"/s||hash = \"$NEW_HASH\"|" flake.nix
+
+          echo "Updated to version $NEW_VERSION with hash $NEW_HASH"
+
+      - name: Update CHANGELOG.md
+        if: steps.check.outputs.needs_update == 'true'
+        run: |
+          set -e
+          NEW_VERSION="${{ steps.latest.outputs.version }}"
+          NEW_TAG_VERSION="${NEW_VERSION}-nix.1"
+          TODAY=$(date +%Y-%m-%d)
+
+          # Use GNU sed via Nix for compatibility with macOS
+          GSED="nix run nixpkgs#gnused --"
+
+          # Get previous release version from CHANGELOG (skip Unreleased)
+          PREV_TAG_VERSION=$($GSED -n 's/^## \[\([^]]*\)\].*/\1/p' CHANGELOG.md | grep -v '^Unreleased$' | head -1)
+
+          # Insert new version section after ## [Unreleased]
+          $GSED -i "/^## \[Unreleased\]/a\\\\n## [${NEW_TAG_VERSION}] - ${TODAY}\\n\\n### Changed\\n\\n- Update octorus to v${NEW_VERSION}" CHANGELOG.md
+
+          # Update [Unreleased] compare link
+          $GSED -i "s|\[Unreleased\]: .*|[Unreleased]: https://github.com/naitokosuke/octorus-nix/compare/${NEW_TAG_VERSION}...HEAD|" CHANGELOG.md
+
+          # Add new version compare link before the previous version link
+          if [ -n "$PREV_TAG_VERSION" ]; then
+            $GSED -i "/^\[${PREV_TAG_VERSION}\]/i [${NEW_TAG_VERSION}]: https://github.com/naitokosuke/octorus-nix/compare/${PREV_TAG_VERSION}...${NEW_TAG_VERSION}" CHANGELOG.md
+          else
+            # No previous version - add link at the end
+            echo "[${NEW_TAG_VERSION}]: https://github.com/naitokosuke/octorus-nix/releases/tag/${NEW_TAG_VERSION}" >> CHANGELOG.md
+          fi
+
+          echo "Updated CHANGELOG.md with version ${NEW_TAG_VERSION}"
+
+      - name: Verify build
+        if: steps.check.outputs.needs_update == 'true'
+        run: |
+          set -e
+          echo "Verifying build with updated flake.nix..."
+          nix build .#octorus --no-link
+          echo "Build successful"
+
+      - name: Create Pull Request
+        if: steps.check.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.OCTORUS_NIX_PR_TOKEN }}
+          commit-message: "feat: update octorus to v${{ steps.latest.outputs.version }}"
+          title: "feat: update octorus to v${{ steps.latest.outputs.version }}"
+          body: |
+            ## octorus version update
+
+            Updates octorus from `v${{ steps.current.outputs.version }}` to `v${{ steps.latest.outputs.version }}`
+
+            ### Changes
+            - Updated version in `flake.nix`
+            - Updated source hash
+            - Updated `CHANGELOG.md`
+
+            ### Links
+            - Tag: https://github.com/ushironoko/octorus/tree/v${{ steps.latest.outputs.version }}
+            - Compare: https://github.com/ushironoko/octorus/compare/v${{ steps.current.outputs.version }}...v${{ steps.latest.outputs.version }}
+
+            ---
+            This PR was automatically created by GitHub Actions
+          branch: update-octorus-${{ steps.latest.outputs.version }}
+          delete-branch: true
+          labels: |
+            dependencies
+            automated


### PR DESCRIPTION
## Summary

- Add `.github/workflows/update-octorus.yml`
- Checks `ushironoko/octorus` for new releases every 12 hours
- On new version: updates `flake.nix` (version + hash), `CHANGELOG.md`, verifies build, creates PR

Closes #3

## Prerequisites (manual setup required)

- [ ] Create a PAT with `contents:write` and `pull-requests:write` scopes
- [ ] Add it as `OCTORUS_NIX_PR_TOKEN` to [repository secrets](https://github.com/naitokosuke/octorus-nix/settings/secrets/actions)

> A PAT is needed instead of `GITHUB_TOKEN` so that the auto-created PR triggers CI workflows.

## Test plan

- [ ] Run workflow manually via `workflow_dispatch` and verify it detects current version as up-to-date
- [ ] Verify PR is created when a new upstream version is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)